### PR TITLE
docs: update gpg installation instructions for Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ sudo cp scrt_1.2.3_linux_x86_64/scrt /usr/local/bin/scrt
 Configure the apt repository:
 
 ```shell
-echo "deb https://apt.scrt.run /" | sudo tee /etc/apt/sources.list.d/scrt.list
-curl "https://apt.scrt.run/key.gpg" | gpg --dearmor > /etc/apt/trusted.gpg.d/scrt.gpg
+echo "deb [signed-by=/usr/share/keyrings/scrt-archive-keyring.gpg] https://apt.scrt.run /" | sudo tee /etc/apt/sources.list.d/scrt.list
+curl "https://apt.scrt.run/key.gpg" | gpg --dearmor | sudo tee /usr/share/keyrings/scrt-archive-keyring.gpg > /dev/null
 ```
 
 Install the binary package:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Configure the apt repository:
 
 ```shell
 echo "deb https://apt.scrt.run /" | sudo tee /etc/apt/sources.list.d/scrt.list
-curl "https://apt.scrt.run/key.gpg" | sudo apt-key add -
+curl "https://apt.scrt.run/key.gpg" | gpg --dearmor > /etc/apt/trusted.gpg.d/scrt.gpg
 ```
 
 Install the binary package:


### PR DESCRIPTION
`apt-key` is now deprecated.

Alternatively, we can use

```
curl "https://apt.scrt.run/key.gpg" | sudo tee /etc/apt/trusted.gpg.d/scrt.asc
```

Some interesting reading: https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html